### PR TITLE
Move CSS to file and refresh palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,76 +1,10 @@
-
 <!DOCTYPE html>
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
   <title>MRM Group - Diagnostic</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      margin: 0;
-      background-color: #000;
-      font-family: 'Segoe UI', sans-serif;
-      color: white;
-      overflow: hidden;
-    }
-    .header {
-      width: 100%;
-      text-align: center;
-      padding: 20px 0;
-      background-color: #000;
-    }
-    .header img {
-      height: 50px;
-    }
-    .chat-screen {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      align-items: center;
-      height: calc(100vh - 80px);
-      padding: 30px;
-      box-sizing: border-box;
-    }
-    .bubble {
-      max-width: 90%;
-      padding: 20px;
-      margin: 10px;
-      border-radius: 16px;
-      font-size: 18px;
-      background-color: #1c1c1c;
-      animation: fadeIn 0.5s ease-in-out;
-      text-align: center;
-    }
-    .response {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      margin-top: 20px;
-    }
-    .btn {
-      background-color: white;
-      color: black;
-      border: none;
-      padding: 15px 24px;
-      font-size: 18px;
-      border-radius: 12px;
-      cursor: pointer;
-      margin: 10px;
-      min-width: 220px;
-    }
-    input {
-      padding: 12px;
-      border-radius: 8px;
-      border: none;
-      font-size: 16px;
-      width: 250px;
-      margin: 10px 0;
-    }
-    @keyframes fadeIn {
-      from {opacity: 0; transform: translateY(20px);}
-      to {opacity: 1; transform: translateY(0);}
-    }
-  </style>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div class="header">

--- a/styles.css
+++ b/styles.css
@@ -1,66 +1,67 @@
-    body {
-      margin: 0;
-      background-color: #222;
-      font-family: 'Segoe UI', sans-serif;
-      color: white;
-    }
-    .header {
-      width: 100%;
-      text-align: center;
-      padding: 20px 0;
-      background-color: #333;
-    }
-    .header img {
-      height: 50px;
-    }
-    .chat-screen {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      align-items: center;
-      height: calc(100vh - 80px);
-      padding: 30px;
-      box-sizing: border-box;
-    }
-    .bubble {
-      max-width: 90%;
-      padding: 20px;
-      margin: 10px;
-      border-radius: 16px;
-      font-size: 18px;
-      background-color: #444;
-      animation: fadeIn 0.5s ease-in-out;
-      text-align: center;
-    }
-    .response {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      margin-top: 20px;
-    }
-    .btn {
-      background-color: #f39c12;
-      color: white;
-      border: none;
-      padding: 15px 24px;
-      font-size: 18px;
-      border-radius: 12px;
-      cursor: pointer;
-      margin: 10px;
-      min-width: 220px;
-    }
-    input {
-      background-color: #333;
-      color: white;
-      padding: 12px;
-      border-radius: 8px;
-      border: none;
-      font-size: 16px;
-      width: 250px;
-      margin: 10px 0;
-    }
-    @keyframes fadeIn {
-      from {opacity: 0; transform: translateY(20px);}
-      to {opacity: 1; transform: translateY(0);}
-    }
+body {
+  margin: 0;
+  background-color: #222;
+  font-family: 'Segoe UI', sans-serif;
+  color: white;
+  overflow-y: auto;
+}
+.header {
+  width: 100%;
+  text-align: center;
+  padding: 20px 0;
+  background-color: #333;
+}
+.header img {
+  height: 50px;
+}
+.chat-screen {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: calc(100vh - 80px);
+  padding: 30px;
+  box-sizing: border-box;
+}
+.bubble {
+  max-width: 90%;
+  padding: 20px;
+  margin: 10px;
+  border-radius: 16px;
+  font-size: 18px;
+  background-color: #444;
+  animation: fadeIn 0.5s ease-in-out;
+  text-align: center;
+}
+.response {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+}
+.btn {
+  background-color: #f39c12;
+  color: white;
+  border: none;
+  padding: 15px 24px;
+  font-size: 18px;
+  border-radius: 12px;
+  cursor: pointer;
+  margin: 10px;
+  min-width: 220px;
+}
+input {
+  background-color: #333;
+  color: white;
+  padding: 12px;
+  border-radius: 8px;
+  border: none;
+  font-size: 16px;
+  width: 250px;
+  margin: 10px 0;
+}
+@keyframes fadeIn {
+  from {opacity: 0; transform: translateY(20px);}
+  to {opacity: 1; transform: translateY(0);}
+}
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,66 @@
+    body {
+      margin: 0;
+      background-color: #222;
+      font-family: 'Segoe UI', sans-serif;
+      color: white;
+    }
+    .header {
+      width: 100%;
+      text-align: center;
+      padding: 20px 0;
+      background-color: #333;
+    }
+    .header img {
+      height: 50px;
+    }
+    .chat-screen {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: center;
+      height: calc(100vh - 80px);
+      padding: 30px;
+      box-sizing: border-box;
+    }
+    .bubble {
+      max-width: 90%;
+      padding: 20px;
+      margin: 10px;
+      border-radius: 16px;
+      font-size: 18px;
+      background-color: #444;
+      animation: fadeIn 0.5s ease-in-out;
+      text-align: center;
+    }
+    .response {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin-top: 20px;
+    }
+    .btn {
+      background-color: #f39c12;
+      color: white;
+      border: none;
+      padding: 15px 24px;
+      font-size: 18px;
+      border-radius: 12px;
+      cursor: pointer;
+      margin: 10px;
+      min-width: 220px;
+    }
+    input {
+      background-color: #333;
+      color: white;
+      padding: 12px;
+      border-radius: 8px;
+      border: none;
+      font-size: 16px;
+      width: 250px;
+      margin: 10px 0;
+    }
+    @keyframes fadeIn {
+      from {opacity: 0; transform: translateY(20px);}
+      to {opacity: 1; transform: translateY(0);}
+    }
+


### PR DESCRIPTION
## Summary
- extract all inline `<style>` rules into `styles.css`
- link the new stylesheet from `index.html`
- update colors to a dark theme with orange accent buttons
- allow page scrolling by removing `overflow: hidden`

## Testing
- `python3 -m http.server 8000` *(served page manually)*

------
https://chatgpt.com/codex/tasks/task_e_684a063639288329934f7f0f5d7d0a6a